### PR TITLE
0.0.10

### DIFF
--- a/api/src/main/java/org/avp/api/common/ai/action/impl/LeapTowardsTargetAction.java
+++ b/api/src/main/java/org/avp/api/common/ai/action/impl/LeapTowardsTargetAction.java
@@ -1,5 +1,6 @@
 package org.avp.api.common.ai.action.impl;
 
+import mod.azure.azurelib.common.api.common.animatable.GeoEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.phys.Vec3;
 
@@ -77,6 +78,9 @@ public class LeapTowardsTargetAction extends CooldownAction {
             mob.getNavigation().stop();
             return;
         }
+
+        if (mob instanceof GeoEntity facehugger)
+            facehugger.triggerAnim("attack", "leap");
 
         distanceToTarget = currentDistanceToTarget;
 

--- a/api/src/main/java/org/avp/api/common/data/block/BlockModelData.java
+++ b/api/src/main/java/org/avp/api/common/data/block/BlockModelData.java
@@ -15,4 +15,6 @@ public record BlockModelData(
         BlockModelDataType.Cube::new,
         BlockModelRenderType.TRANSLUCENT
     );
+
+    public static final BlockModelData CUTOUT_CUBE = new BlockModelData(BlockModelDataType.Cube::new, BlockModelRenderType.CUTOUT);
 }

--- a/common/src/main/java/org/avp/common/AVPConstants.java
+++ b/common/src/main/java/org/avp/common/AVPConstants.java
@@ -1,7 +1,5 @@
 package org.avp.common;
 
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.player.Player;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,8 +10,6 @@ public class AVPConstants {
     public static final String MOD_NAME = "AliensVsPredator";
 
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_NAME);
-
-    public static Predicate<Entity> isCreativeSpecPlayer = entity -> (entity instanceof Player playerEntity && (playerEntity.isCreative() || playerEntity.isSpectator()));
 
     private AVPConstants() {
         throw new UnsupportedOperationException();

--- a/common/src/main/java/org/avp/common/AVPConstants.java
+++ b/common/src/main/java/org/avp/common/AVPConstants.java
@@ -1,5 +1,7 @@
 package org.avp.common;
 
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10,6 +12,8 @@ public class AVPConstants {
     public static final String MOD_NAME = "AliensVsPredator";
 
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_NAME);
+
+    public static Predicate<Entity> isCreativeSpecPlayer = entity -> (entity instanceof Player playerEntity && (playerEntity.isCreative() || playerEntity.isSpectator()));
 
     private AVPConstants() {
         throw new UnsupportedOperationException();

--- a/common/src/main/java/org/avp/common/ai/AIUtils.java
+++ b/common/src/main/java/org/avp/common/ai/AIUtils.java
@@ -45,7 +45,7 @@ public class AIUtils {
             2,
             new NearestAttackableTargetGoal<>(
                 monster,
-                LivingEntity.class,
+                Mob.class,
                 true,
                 livingEntity -> {
                     var shouldKill = !livingEntity.getType().is(AVPEntityTypeTags.ALIENS) &&

--- a/common/src/main/java/org/avp/common/ai/parasite/ParasiteBrain.java
+++ b/common/src/main/java/org/avp/common/ai/parasite/ParasiteBrain.java
@@ -40,9 +40,7 @@ public class ParasiteBrain extends GOAPBrain {
             new ClosestTargetSensor(
                 cache,
                 parasite,
-                maybeTarget -> AVPPredicates.IS_HOST.test(maybeTarget) &&
-                // If target has no passengers or if the parasite is attached to the target.
-                    (maybeTarget.getPassengers().isEmpty() || parasite.getVehicle() == maybeTarget)
+                maybeTarget -> AVPPredicates.IS_HOST.test(maybeTarget) && maybeTarget.getPassengers().stream().noneMatch(AbstractParasite.class::isInstance)
             )
         );
     }

--- a/common/src/main/java/org/avp/common/ai/parasite/ParasiteBrain.java
+++ b/common/src/main/java/org/avp/common/ai/parasite/ParasiteBrain.java
@@ -2,6 +2,7 @@ package org.avp.common.ai.parasite;
 
 import java.util.List;
 
+import net.minecraft.world.entity.Mob;
 import org.avp.api.common.ai.GOAPBrain;
 import org.avp.api.common.ai.action.impl.LeapTowardsTargetAction;
 import org.avp.api.common.ai.goal.impl.MoveToTargetGoal;
@@ -40,7 +41,7 @@ public class ParasiteBrain extends GOAPBrain {
             new ClosestTargetSensor(
                 cache,
                 parasite,
-                maybeTarget -> AVPPredicates.IS_HOST.test(maybeTarget) && maybeTarget.getPassengers().stream().noneMatch(AbstractParasite.class::isInstance)
+                maybeTarget -> AVPPredicates.IS_HOST.test(maybeTarget) && maybeTarget.getPassengers().stream().noneMatch(AbstractParasite.class::isInstance) && maybeTarget instanceof Mob
             )
         );
     }

--- a/common/src/main/java/org/avp/common/animation/FacehuggerAnimations.java
+++ b/common/src/main/java/org/avp/common/animation/FacehuggerAnimations.java
@@ -16,6 +16,8 @@ public class FacehuggerAnimations {
 
     private static final String CONTROLLER_NAME_MOVE = "move";
 
+    private static final String CONTROLLER_NAME_ATTACK = "attack";
+
     private static final String ANIMATION_NAME_TAIL_SWAY = "animation.tailsway";
 
     private static final String ANIMATION_NAME_WALK = "animation.walk";
@@ -29,7 +31,7 @@ public class FacehuggerAnimations {
     private static final RawAnimation ANIMATION_FACEHUG = RawAnimation.begin().thenPlayAndHold(ANIMATION_NAME_FACEHUG);
 
     private static final Function<Facehugger, AnimationController.AnimationStateHandler<GeoAnimatable>> HANDLER_IDLE = entity -> event -> {
-        if (!event.isMoving() && entity.isFertile()) {
+        if (!event.isMoving() && entity.isFertile() && !entity.isPassenger()) {
             return event.setAndContinue(ANIMATION_TAIL_SWAY);
         }
 
@@ -38,20 +40,24 @@ public class FacehuggerAnimations {
 
     private static final Function<Facehugger, AnimationController.AnimationStateHandler<GeoAnimatable>> HANDLER_MOVEMENT =
         entity -> event -> {
-            if (event.isMoving() && entity.isFertile()) {
+            if (event.isMoving() && entity.isFertile() && !entity.isPassenger()) {
                 return event.setAndContinue(ANIMATION_CRAWL);
             }
             if (entity.isPassenger()) {
                 return event.setAndContinue(ANIMATION_FACEHUG);
             }
-            
+
             return PlayState.STOP;
         };
+
+    private static final Function<Facehugger, AnimationController.AnimationStateHandler<GeoAnimatable>> HANDLER_ATTACK =
+            entity -> event -> PlayState.CONTINUE;
 
     public static <T extends Facehugger & GeoAnimatable> void bootstrap(T entity, AnimatableManager.ControllerRegistrar registrar) {
         registrar.add(
             new AnimationController<>(entity, CONTROLLER_NAME_IDLE, HANDLER_IDLE.apply(entity)),
-            new AnimationController<>(entity, CONTROLLER_NAME_MOVE, HANDLER_MOVEMENT.apply(entity))
+            new AnimationController<>(entity, CONTROLLER_NAME_MOVE, HANDLER_MOVEMENT.apply(entity)),
+            new AnimationController<>(entity, CONTROLLER_NAME_ATTACK, HANDLER_ATTACK.apply(entity)).triggerableAnim("leap", RawAnimation.begin().thenPlay("animation.leap"))
         );
     }
 

--- a/common/src/main/java/org/avp/common/animation/FacehuggerAnimations.java
+++ b/common/src/main/java/org/avp/common/animation/FacehuggerAnimations.java
@@ -20,9 +20,13 @@ public class FacehuggerAnimations {
 
     private static final String ANIMATION_NAME_WALK = "animation.walk";
 
+    private static final String ANIMATION_NAME_FACEHUG = "animation.facehug";
+
     private static final RawAnimation ANIMATION_CRAWL = RawAnimation.begin().thenPlay(ANIMATION_NAME_WALK);
 
     private static final RawAnimation ANIMATION_TAIL_SWAY = RawAnimation.begin().thenPlay(ANIMATION_NAME_TAIL_SWAY);
+
+    private static final RawAnimation ANIMATION_FACEHUG = RawAnimation.begin().thenPlayAndHold(ANIMATION_NAME_FACEHUG);
 
     private static final Function<Facehugger, AnimationController.AnimationStateHandler<GeoAnimatable>> HANDLER_IDLE = entity -> event -> {
         if (!event.isMoving() && entity.isFertile()) {
@@ -37,7 +41,10 @@ public class FacehuggerAnimations {
             if (event.isMoving() && entity.isFertile()) {
                 return event.setAndContinue(ANIMATION_CRAWL);
             }
-
+            if (entity.isPassenger()) {
+                return event.setAndContinue(ANIMATION_FACEHUG);
+            }
+            
             return PlayState.STOP;
         };
 

--- a/common/src/main/java/org/avp/common/animation/FacehuggerRoyalAnimations.java
+++ b/common/src/main/java/org/avp/common/animation/FacehuggerRoyalAnimations.java
@@ -16,6 +16,8 @@ public class FacehuggerRoyalAnimations {
 
     private static final String CONTROLLER_NAME_MOVE = "move";
 
+    private static final String CONTROLLER_NAME_ATTACK = "attack";
+
     private static final String ANIMATION_NAME_TAIL_SWAY = "animation.tailsway";
 
     private static final String ANIMATION_NAME_WALK = "animation.walk";
@@ -45,14 +47,18 @@ public class FacehuggerRoyalAnimations {
             if (entity.isPassenger()) {
                 return event.setAndContinue(ANIMATION_FACEHUG);
             }
-            
+
             return PlayState.STOP;
         };
 
+    private static final Function<FacehuggerRoyal, AnimationController.AnimationStateHandler<GeoAnimatable>> HANDLER_ATTACK =
+            entity -> event -> PlayState.CONTINUE;
+
     public static <T extends FacehuggerRoyal & GeoAnimatable> void bootstrap(T entity, AnimatableManager.ControllerRegistrar registrar) {
         registrar.add(
-            new AnimationController<>(entity, CONTROLLER_NAME_IDLE, HANDLER_IDLE.apply(entity)),
-            new AnimationController<>(entity, CONTROLLER_NAME_MOVE, HANDLER_MOVEMENT.apply(entity))
+                new AnimationController<>(entity, CONTROLLER_NAME_IDLE, HANDLER_IDLE.apply(entity)),
+                new AnimationController<>(entity, CONTROLLER_NAME_MOVE, HANDLER_MOVEMENT.apply(entity)),
+                new AnimationController<>(entity, CONTROLLER_NAME_ATTACK, HANDLER_ATTACK.apply(entity)).triggerableAnim("leap", RawAnimation.begin().thenPlay("animation.leap"))
         );
     }
 

--- a/common/src/main/java/org/avp/common/animation/FacehuggerRoyalAnimations.java
+++ b/common/src/main/java/org/avp/common/animation/FacehuggerRoyalAnimations.java
@@ -20,9 +20,13 @@ public class FacehuggerRoyalAnimations {
 
     private static final String ANIMATION_NAME_WALK = "animation.walk";
 
+    private static final String ANIMATION_NAME_FACEHUG = "animation.facehug";
+
     private static final RawAnimation ANIMATION_CRAWL = RawAnimation.begin().thenPlay(ANIMATION_NAME_WALK);
 
     private static final RawAnimation ANIMATION_TAIL_SWAY = RawAnimation.begin().thenPlay(ANIMATION_NAME_TAIL_SWAY);
+
+    private static final RawAnimation ANIMATION_FACEHUG = RawAnimation.begin().thenPlayAndHold(ANIMATION_NAME_FACEHUG);
 
     private static final Function<FacehuggerRoyal, AnimationController.AnimationStateHandler<GeoAnimatable>> HANDLER_IDLE =
         entity -> event -> {
@@ -38,7 +42,10 @@ public class FacehuggerRoyalAnimations {
             if (event.isMoving()) {
                 return event.setAndContinue(ANIMATION_CRAWL);
             }
-
+            if (entity.isPassenger()) {
+                return event.setAndContinue(ANIMATION_FACEHUG);
+            }
+            
             return PlayState.STOP;
         };
 

--- a/common/src/main/java/org/avp/common/config/AVPConfig.java
+++ b/common/src/main/java/org/avp/common/config/AVPConfig.java
@@ -68,6 +68,16 @@ public class AVPConfig {
         public static float ACID_DAMAGE = 2F;
 
         @Config(
+                value = "acidBreakspeedModifier",
+                comment = """
+                The modifier that controls how fast acid is.
+                Higher numbers is slower, lower is faster
+                Default Value: 40.0
+                """
+        )
+        public static float ACID_BREAKSPEED_MODIFIER = 40F;
+
+        @Config(
             value = "gunsDoBlockDamage",
             comment = """
                 Whether guns do block damage or not. Disabling this does not disable explosive block damage.

--- a/common/src/main/java/org/avp/common/data/block/AlienBlockSetDataContainer.java
+++ b/common/src/main/java/org/avp/common/data/block/AlienBlockSetDataContainer.java
@@ -79,7 +79,7 @@ public class AlienBlockSetDataContainer extends ExtendedBlockDataContainer imple
             new SingleBlockDataContainer(
                 () -> new Block(RESIN_PROPERTIES),
                 "resin_webbing",
-                BlockModelData.NORMAL_CUBE,
+                BlockModelData.CUTOUT_CUBE,
                 BLOCK_TAGS,
                 LootProviders.SELF
             )

--- a/common/src/main/java/org/avp/common/data/block/AlienBlockSetDataContainer.java
+++ b/common/src/main/java/org/avp/common/data/block/AlienBlockSetDataContainer.java
@@ -22,12 +22,13 @@ import org.avp.api.common.data.block.SingleBlockDataContainer;
 import org.avp.api.common.data.loot_table.LootProviders;
 import org.avp.common.data.recipe.AVPRecipeBuilder;
 import org.avp.common.game.block.ResinVeinBlock;
+import org.avp.common.game.block.ResinWebbingBlock;
 import org.avp.common.registry.item.AVPItemRegistry;
 
 public class AlienBlockSetDataContainer extends ExtendedBlockDataContainer implements RecipeCreator {
 
     private static final BlockBehaviour.Properties RESIN_PROPERTIES = BlockBehaviour.Properties.ofFullCopy(Blocks.STONE)
-        .mapColor(MapColor.COLOR_GRAY);
+        .mapColor(MapColor.COLOR_GRAY).noCollission().noOcclusion();
 
     // FIXME:
     private static final BlockBehaviour.Properties RESIN_VEIN_PROPERTIES = BlockBehaviour.Properties.of()
@@ -77,7 +78,7 @@ public class AlienBlockSetDataContainer extends ExtendedBlockDataContainer imple
         // FIXME: fix model data
         this.resinWebbing = this.addVariant(
             new SingleBlockDataContainer(
-                () -> new Block(RESIN_PROPERTIES),
+                () -> new ResinWebbingBlock(RESIN_PROPERTIES),
                 "resin_webbing",
                 BlockModelData.CUTOUT_CUBE,
                 BLOCK_TAGS,

--- a/common/src/main/java/org/avp/common/data/entity/AVPEntitySpeedConstants.java
+++ b/common/src/main/java/org/avp/common/data/entity/AVPEntitySpeedConstants.java
@@ -23,7 +23,7 @@ public class AVPEntitySpeedConstants {
 
     public static final double DRACOMORPH_SPEED = PLAYER_SPRINT_SPEED * 0.95;
 
-    public static final double DRONE_SPEED = PLAYER_SPRINT_SPEED * 0.9;
+    public static final double DRONE_SPEED = PLAYER_SPRINT_SPEED * 1.3;
 
     public static final double DRONE_RUNNER_SPEED = PLAYER_SPRINT_JUMP_SPEED * 1.05;
 

--- a/common/src/main/java/org/avp/common/data/tag/AVPBlockTags.java
+++ b/common/src/main/java/org/avp/common/data/tag/AVPBlockTags.java
@@ -18,6 +18,8 @@ public class AVPBlockTags {
 
     public static final TagKey<Block> SHOULD_NOT_BE_DESTROYED = create("should_not_be_destroyed");
 
+    public static final TagKey<Block> RESIN_WEBBING = create("resin_webbing");
+
     private static TagKey<Block> create(String registryName) {
         return TagKey.create(Registries.BLOCK, AVPResources.location(registryName));
     }

--- a/common/src/main/java/org/avp/common/game/block/ResinWebbingBlock.java
+++ b/common/src/main/java/org/avp/common/game/block/ResinWebbingBlock.java
@@ -7,7 +7,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
-import org.avp.common.AVPConstants;
+import org.avp.api.util.BLPredicates;
 import org.avp.common.data.tag.AVPEntityTypeTags;
 import org.jetbrains.annotations.NotNull;
 
@@ -21,7 +21,7 @@ public class ResinWebbingBlock extends Block {
     @Override
     public void entityInside(@NotNull BlockState state, @NotNull Level world, @NotNull BlockPos pos, @NotNull Entity entity) {
         if (entity.getType().is(AVPEntityTypeTags.ALIENS)) return;
-        if (AVPConstants.isCreativeSpecPlayer.test(entity)) return;
+        if (entity instanceof LivingEntity livingEntity && BLPredicates.IS_IMMORTAL.test(livingEntity)) return;
         if (entity instanceof LivingEntity livingEntity) {
             livingEntity.makeStuckInBlock(state, new Vec3(0.25, 0.05F, 0.25));
             if (!world.isClientSide())

--- a/common/src/main/java/org/avp/common/game/block/ResinWebbingBlock.java
+++ b/common/src/main/java/org/avp/common/game/block/ResinWebbingBlock.java
@@ -1,0 +1,41 @@
+package org.avp.common.game.block;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
+import org.avp.common.AVPConstants;
+import org.avp.common.data.tag.AVPEntityTypeTags;
+import org.jetbrains.annotations.NotNull;
+
+public class ResinWebbingBlock extends Block {
+    private int standingTick = 0;
+
+    public ResinWebbingBlock(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public void entityInside(@NotNull BlockState state, @NotNull Level world, @NotNull BlockPos pos, @NotNull Entity entity) {
+        if (entity.getType().is(AVPEntityTypeTags.ALIENS)) return;
+        if (AVPConstants.isCreativeSpecPlayer.test(entity)) return;
+        if (entity instanceof LivingEntity livingEntity) {
+            livingEntity.makeStuckInBlock(state, new Vec3(0.25, 0.05F, 0.25));
+            if (!world.isClientSide())
+                standingTick++;
+            if (standingTick >= 100) {
+                if (!world.getBlockState(pos.below()).is(this))
+                    livingEntity.setPos(pos.getCenter().x, pos.getY(), pos.getCenter().z);
+                if (world.getBlockState(pos.below()).is(this))
+                    livingEntity.setPos(pos.getCenter().x, pos.below().getY(), pos.getCenter().z);
+                livingEntity.makeStuckInBlock(state, new Vec3(0.25, 0.0F, 0.25));
+                standingTick = 0;
+            }
+        } else {
+            standingTick = 0;
+        }
+    }
+}

--- a/common/src/main/java/org/avp/common/game/entity/Acid.java
+++ b/common/src/main/java/org/avp/common/game/entity/Acid.java
@@ -100,6 +100,8 @@ public class Acid extends Entity {
                     kill();
                 }
             }
+            if (tickCount >= 140)
+                kill();
         }
     }
 

--- a/common/src/main/java/org/avp/common/game/entity/Acid.java
+++ b/common/src/main/java/org/avp/common/game/entity/Acid.java
@@ -122,8 +122,7 @@ public class Acid extends Entity {
         }
 
         if (!blockState.is(AVPBlockTags.ACID_IMMUNE)) {
-            // TODO: Make this break speed configurable.
-            BlockBreakProgressManager.damage(level(), blockPos, (2F * getMultiplier()) / 20F);
+            BlockBreakProgressManager.damage(level(), blockPos, (2F * getMultiplier()) / AVPConfig.General.ACID_BREAKSPEED_MODIFIER);
         }
     }
 

--- a/common/src/main/java/org/avp/common/game/entity/Rocket.java
+++ b/common/src/main/java/org/avp/common/game/entity/Rocket.java
@@ -4,10 +4,15 @@ import mod.azure.azurelib.common.api.common.animatable.GeoEntity;
 import mod.azure.azurelib.common.internal.common.core.animatable.instance.AnimatableInstanceCache;
 import mod.azure.azurelib.common.internal.common.core.animation.AnimatableManager;
 import mod.azure.azurelib.common.internal.common.util.AzureLibUtil;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.projectile.ProjectileUtil;
 import net.minecraft.world.entity.projectile.ThrowableProjectile;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.TheEndGatewayBlockEntity;
+import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import org.jetbrains.annotations.NotNull;
 
@@ -37,11 +42,50 @@ public class Rocket extends ThrowableProjectile implements GeoEntity {
     }
 
     @Override
+    public void tick() {
+        this.baseTick();
+        var deltaMovement = this.getDeltaMovement();
+        var nextX = this.getX() + deltaMovement.x;
+        var nextY = this.getY() + deltaMovement.y;
+        var nextZ = this.getZ() + deltaMovement.z;
+        var hitResult = ProjectileUtil.getHitResultOnMoveVector(this, this::canHitEntity);
+        boolean portalOrGatewayHit = false;
+        if (hitResult.getType() == HitResult.Type.BLOCK) {
+            var blockPos = ((BlockHitResult) hitResult).getBlockPos();
+            var blockState = this.level().getBlockState(blockPos);
+            if (blockState.is(Blocks.NETHER_PORTAL)) {
+                this.handleInsidePortal(blockPos);
+                portalOrGatewayHit = true;
+            } else if (blockState.is(Blocks.END_GATEWAY)) {
+                if (this.level().getBlockEntity(blockPos) instanceof TheEndGatewayBlockEntity theEndGatewayBlockEntity && TheEndGatewayBlockEntity.canEntityTeleport(this))
+                    TheEndGatewayBlockEntity.teleportEntity(this.level(), blockPos, blockState, this, theEndGatewayBlockEntity);
+                portalOrGatewayHit = true;
+            }
+        }
+        if (hitResult.getType() != HitResult.Type.MISS && !portalOrGatewayHit)
+            this.onHit(hitResult);
+        this.checkInsideBlocks();
+        this.updateRotation();
+        this.setDeltaMovement(deltaMovement.scale(this.isInWater() ? 0.8F: 0.99F));
+        if (!this.isNoGravity())
+            this.setDeltaMovement(deltaMovement.x, deltaMovement.y - this.getGravity(), deltaMovement.z);
+        this.setPos(nextX, nextY, nextZ);
+        if (this.level().isClientSide() && this.isInWater())
+            for (int k = 0; k < 4; ++k)
+                this.level().addParticle(ParticleTypes.BUBBLE, nextX - deltaMovement.x * 0.25, nextY - deltaMovement.y * 0.25, nextZ - deltaMovement.z * 0.25, deltaMovement.x, deltaMovement.y, deltaMovement.z);
+    }
+
+    @Override
     protected void defineSynchedData() { /* NO-OP */ }
 
     @Override
     protected float getGravity() {
         return 0F;
+    }
+
+    @Override
+    public boolean shouldRenderAtSqrDistance(double $$0) {
+        return true;
     }
 
     @Override

--- a/common/src/main/java/org/avp/common/game/item/AbstractAVPWeaponItem.java
+++ b/common/src/main/java/org/avp/common/game/item/AbstractAVPWeaponItem.java
@@ -2,8 +2,12 @@ package org.avp.common.game.item;
 
 import mod.azure.azurelib.common.api.common.animatable.GeoItem;
 import mod.azure.azurelib.common.internal.client.RenderProvider;
+import mod.azure.azurelib.common.internal.common.animatable.SingletonGeoAnimatable;
 import mod.azure.azurelib.common.internal.common.core.animatable.instance.AnimatableInstanceCache;
 import mod.azure.azurelib.common.internal.common.core.animation.AnimatableManager;
+import mod.azure.azurelib.common.internal.common.core.animation.AnimationController;
+import mod.azure.azurelib.common.internal.common.core.animation.RawAnimation;
+import mod.azure.azurelib.common.internal.common.core.object.PlayState;
 import mod.azure.azurelib.common.internal.common.util.AzureLibUtil;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.network.chat.Component;
@@ -47,6 +51,7 @@ public abstract class AbstractAVPWeaponItem extends Item implements GeoItem {
     protected AbstractAVPWeaponItem(Properties properties, WeaponData weaponData) {
         super(properties.stacksTo(1).durability(weaponData.getDurability()));
         this.weaponData = weaponData;
+        SingletonGeoAnimatable.registerSyncedAnimatable(this);
     }
 
     @Override
@@ -114,6 +119,7 @@ public abstract class AbstractAVPWeaponItem extends Item implements GeoItem {
                         % backgroundShootSoundFrequency == 0
                 ) {
                     level.playSound(null, player.blockPosition(), backgroundShootSound, SoundSource.PLAYERS);
+                    triggerAnim(serverPlayer, GeoItem.getOrAssignId(itemStack, serverLevel), "main", "spin");
                 }
             });
 
@@ -124,6 +130,7 @@ public abstract class AbstractAVPWeaponItem extends Item implements GeoItem {
                 if (reloadBehavior == ReloadBehavior.LOAD_FROM_INVENTORY) {
                     reloadBehavior.tryReload(serverLevel, serverPlayer, weaponItemStack);
                 }
+                triggerAnim(serverPlayer, GeoItem.getOrAssignId(itemStack, serverLevel), "main", "spin");
                 fire(level, player, weaponItemStack, positiveTickProgress);
             } else {
                 reloadBehavior.tryReload(serverLevel, serverPlayer, weaponItemStack);
@@ -211,7 +218,7 @@ public abstract class AbstractAVPWeaponItem extends Item implements GeoItem {
 
     @Override
     public void registerControllers(AnimatableManager.ControllerRegistrar controllers) {
-        // Do nothing
+        controllers.add(new AnimationController<>(this, "main", event -> PlayState.CONTINUE).triggerableAnim("spin", RawAnimation.begin().thenPlay("barrelspin")));
     }
 
     @Override

--- a/common/src/main/java/org/avp/common/game/item/AbstractAVPWeaponItem.java
+++ b/common/src/main/java/org/avp/common/game/item/AbstractAVPWeaponItem.java
@@ -120,7 +120,7 @@ public abstract class AbstractAVPWeaponItem extends Item implements GeoItem {
             var hasAmmunition = fireMode.ammunitionData().hasAmmunitionBehavior().hasAmmunition(serverLevel, serverPlayer, weaponItemStack);
             var reloadBehavior = fireMode.reloadData().reloadBehavior();
 
-            if (hasAmmunition) {
+            if (hasAmmunition || serverPlayer.isCreative()) {
                 if (reloadBehavior == ReloadBehavior.LOAD_FROM_INVENTORY) {
                     reloadBehavior.tryReload(serverLevel, serverPlayer, weaponItemStack);
                 }

--- a/common/src/main/java/org/avp/mixin/MixinLivingEntity_PreventMovementWhenHugged.java
+++ b/common/src/main/java/org/avp/mixin/MixinLivingEntity_PreventMovementWhenHugged.java
@@ -1,0 +1,24 @@
+package org.avp.mixin;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.Level;
+import org.avp.common.game.entity.AbstractFacehugger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(LivingEntity.class)
+public abstract class MixinLivingEntity_PreventMovementWhenHugged extends Entity {
+
+    public MixinLivingEntity_PreventMovementWhenHugged(EntityType<?> $$0, Level $$1) {
+        super($$0, $$1);
+    }
+
+    @Inject(method = {"isImmobile"}, at = {@At("RETURN")}, cancellable = true)
+    protected void isImmobile(CallbackInfoReturnable<Boolean> callbackInfo) {
+        if (this.getPassengers().stream().anyMatch(AbstractFacehugger.class::isInstance)) callbackInfo.setReturnValue(true);
+    }
+}

--- a/common/src/main/java/org/avp/mixin/client/MixinInGameOverlayRenderer.java
+++ b/common/src/main/java/org/avp/mixin/client/MixinInGameOverlayRenderer.java
@@ -8,7 +8,7 @@ import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.ScreenEffectRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
-import org.avp.common.AVPConstants;
+import org.avp.api.util.BLPredicates;
 import org.avp.common.AVPResources;
 import org.avp.common.data.tag.AVPBlockTags;
 import org.joml.Matrix4f;
@@ -24,7 +24,7 @@ public class MixinInGameOverlayRenderer {
 
     @Inject(method = {"renderScreenEffect"}, at = {@At("RETURN")})
     private static void renderOverlays(Minecraft client, PoseStack matrices, CallbackInfo ci) {
-        if (!AVPConstants.isCreativeSpecPlayer.test(client.player) && client.player.level().getBlockState(client.player.blockPosition()).is(AVPBlockTags.RESIN_WEBBING)) {
+        if (!BLPredicates.IS_IMMORTAL.test(client.player) && client.player.level().getBlockState(client.player.blockPosition()).is(AVPBlockTags.RESIN_WEBBING)) {
             renderOverlay(client, matrices, 1, RESIN_OVERLAY_TEXTURE);
         }
     }

--- a/common/src/main/java/org/avp/mixin/client/MixinInGameOverlayRenderer.java
+++ b/common/src/main/java/org/avp/mixin/client/MixinInGameOverlayRenderer.java
@@ -1,0 +1,57 @@
+package org.avp.mixin.client;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.*;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.LightTexture;
+import net.minecraft.client.renderer.ScreenEffectRenderer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import org.avp.common.AVPConstants;
+import org.avp.common.AVPResources;
+import org.avp.common.data.tag.AVPBlockTags;
+import org.joml.Matrix4f;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ScreenEffectRenderer.class)
+public class MixinInGameOverlayRenderer {
+
+    private static final ResourceLocation RESIN_OVERLAY_TEXTURE = AVPResources.location("textures/block/resin_webbing.png");
+
+    @Inject(method = {"renderScreenEffect"}, at = {@At("RETURN")})
+    private static void renderOverlays(Minecraft client, PoseStack matrices, CallbackInfo ci) {
+        if (!AVPConstants.isCreativeSpecPlayer.test(client.player) && client.player.level().getBlockState(client.player.blockPosition()).is(AVPBlockTags.RESIN_WEBBING)) {
+            renderOverlay(client, matrices, 1, RESIN_OVERLAY_TEXTURE);
+        }
+    }
+
+    private static void renderOverlay(Minecraft client, PoseStack matrices, float progress, ResourceLocation resourceLocation) {
+        RenderSystem.disableDepthTest();
+        RenderSystem.depthMask(false);
+        RenderSystem.defaultBlendFunc();
+        RenderSystem.setShader(GameRenderer::getPositionTexShader);
+        RenderSystem.setShaderTexture(0, resourceLocation);
+        BlockPos blockpos = BlockPos.containing(client.player.getX(), client.player.getEyeY(), client.player.getZ());
+        float f = LightTexture.getBrightness(client.player.level().dimensionType(), client.player.level().getMaxLocalRawBrightness(blockpos));
+        RenderSystem.enableBlend();
+        RenderSystem.setShaderColor(f, f, f, progress);
+        float f7 = -client.player.getYRot() / 64.0F;
+        float f8 = client.player.getXRot() / 64.0F;
+        Matrix4f matrix4f = matrices.last().pose();
+        BufferBuilder bufferbuilder = Tesselator.getInstance().getBuilder();
+        bufferbuilder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
+        bufferbuilder.vertex(matrix4f, -1.0F, -1.0F, -0.5F).uv(4.0F + f7, 4.0F + f8).endVertex();
+        bufferbuilder.vertex(matrix4f, 1.0F, -1.0F, -0.5F).uv(0.0F + f7, 4.0F + f8).endVertex();
+        bufferbuilder.vertex(matrix4f, 1.0F, 1.0F, -0.5F).uv(0.0F + f7, 0.0F + f8).endVertex();
+        bufferbuilder.vertex(matrix4f, -1.0F, 1.0F, -0.5F).uv(4.0F + f7, 0.0F + f8).endVertex();
+        BufferUploader.drawWithShader(bufferbuilder.end());
+        RenderSystem.depthMask(true);
+        RenderSystem.enableDepthTest();
+        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 0.5F);
+        RenderSystem.disableBlend();
+    }
+}

--- a/common/src/main/resources/avp.mixins.json
+++ b/common/src/main/resources/avp.mixins.json
@@ -20,6 +20,7 @@
         "MixinLivingEntity_ReduceWaterSlowDownForAliens",
         "MixinLivingEntity_RoyalJellyHolder",
         "MixinLivingEntity_Host",
+        "MixinLivingEntity_PreventMovementWhenHugged",
         "MixinLivingEntity_ProduceAcid",
         "MixinLivingEntity_ReduceFallDamage",
         "MixinLivingEntity_SyncedDataHandleUser",

--- a/common/src/main/resources/avp.mixins.json
+++ b/common/src/main/resources/avp.mixins.json
@@ -36,6 +36,7 @@
     ],
     "client": [
         "client.MixinGuiGraphics",
+        "client.MixinInGameOverlayRenderer",
         "client.MixinMinecraft_Accessor",
         "client.MixinPlayerRenderer"
     ],

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ version                       = 0.0.9
 group                         = org.avp
 
 # Common
-credits                       = Boston Vanseghi, Caution, Cybercat5555, Glixyl, Gothic Lycan, Hossaurus, Pheonix_Atredes, Ri5ux, Shift, Spookyboo117, The Digital Diamonds, Ulandos, Xavier
+credits                       = Boston Vanseghi, Azuredoom, Caution, Cybercat5555, Glixyl, Gothic Lycan, Hossaurus, Pheonix_Atredes, Ri5ux, Shift, Spookyboo117, The Digital Diamonds, Ulandos, Xavier
 description                   = Adds a variety of content from both the Alien and Predator franchises!
 license                       = C0-1.0
 minecraft_version             = 1.20.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.daemon             = false
 org.gradle.jvmargs            = -Xmx3G
 
 # Project
-version                       = 0.0.9
+version                       = 0.0.10
 group                         = org.avp
 
 # Common


### PR DESCRIPTION
- Fixes Rockets not despawning
- Fixes Rockets stuck in water
- Sets a max 7-second lifetime on acid
- Add Acid break speed modifier config
- Use Acid break speed modifier config
- Resin Webbing is now a cross block with cutout
- Adds dedicated ResinWebbingBlock with the ability to make the player stuck
- Adds Resin Web Block tag
- Adds Mixin for giving an overlay when in resin webbing
- Resin now rotates when placed
- Fixes huggers attacking mobs when facehugging them
- Facehugger plays hugged animation now
- Royal Facehugger plays hugged animation now
- Add leap trigger animation to Facehugger
- Add leap trigger animation to Royal  Facehugger
- Facehuggers only target Mobs now 
- Fixes attacking armor stands
- Buff Drone speed
- Fixes Guns requring ammo in creative mode
- Adds Minigun spin 