### PR TITLE
Fix gankolib animated textures conflict

### DIFF
--- a/common/src/main/java/com/blib/api/client/texture/v1/AnimatableTexture.java
+++ b/common/src/main/java/com/blib/api/client/texture/v1/AnimatableTexture.java
@@ -93,9 +93,10 @@ public class AnimatableTexture extends SimpleTexture {
     public static void setAndUpdate(ResourceLocation texturePath, int frameTick) {
         AbstractTexture texture = Minecraft.getInstance().getTextureManager().getTexture(texturePath);
 
-        if (texture instanceof AnimatableTexture animatableTexture) {
-            animatableTexture.setAnimationFrame(frameTick);
-        }
+        try {
+            var method = texture.getClass().getMethod("setAnimationFrame", int.class);
+            method.invoke(texture, frameTick);
+        } catch (ReflectiveOperationException ignored) {}
 
         RenderSystem.setShaderTexture(0, texture.getId());
     }

--- a/common/src/main/java/com/blib/internal/mixin/azurelib/TextureManagerMixin.java
+++ b/common/src/main/java/com/blib/internal/mixin/azurelib/TextureManagerMixin.java
@@ -1,43 +1,46 @@
 package com.blib.internal.mixin.azurelib;
 
 import net.minecraft.client.renderer.texture.AbstractTexture;
+import net.minecraft.client.renderer.texture.SimpleTexture;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.resources.ResourceLocation;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.Map;
-
 import com.blib.api.client.texture.v1.AnimatableTexture;
 
-@Mixin(value = TextureManager.class, priority = 900)
+@Mixin(value = TextureManager.class, priority = 2010)
 public abstract class TextureManagerMixin {
-
-    @Shadow
-    @Final
-    private Map<ResourceLocation, AbstractTexture> byPath;
 
     @Shadow
     public abstract void register(ResourceLocation resourceLocation, AbstractTexture abstractTexture);
 
     @Inject(
         method = "getTexture(Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/renderer/texture/AbstractTexture;",
-        at = @At("HEAD")
+        at = @At("RETURN"),
+        cancellable = true,
+        require = 0
     )
-    private void wrapAnimatableTexture(ResourceLocation path, CallbackInfoReturnable<AbstractTexture> callback) {
-        AbstractTexture existing = this.byPath.get(path);
+    private void blib$replaceAnimatableTexture(
+        ResourceLocation location,
+        CallbackInfoReturnable<AbstractTexture> cir
+    ) {
+        AbstractTexture currentTexture = cir.getReturnValue();
 
-        if (existing == null) {
-            AnimatableTexture animatableTexture = new AnimatableTexture(path);
-
-            register(path, animatableTexture);
-
-            if (!animatableTexture.isAnimated())
-                this.byPath.remove(path);
+        if (currentTexture == null || currentTexture.getClass() != SimpleTexture.class) {
+            return;
         }
+
+        AnimatableTexture animatableTexture = new AnimatableTexture(location);
+
+        if (!animatableTexture.isAnimated()) {
+            return;
+        }
+
+        this.register(location, animatableTexture);
+        cir.setReturnValue(animatableTexture);
     }
 }

--- a/common/src/main/java/com/blib/internal/mixin/azurelib/TextureManagerMixin.java
+++ b/common/src/main/java/com/blib/internal/mixin/azurelib/TextureManagerMixin.java
@@ -21,10 +21,10 @@ import com.blib.api.client.texture.v1.AnimatableTexture;
 public abstract class TextureManagerMixin {
 
     @Unique
-    private final Map<ResourceLocation, Boolean> blit$animationCache = new HashMap<>();
+    private final Map<ResourceLocation, Boolean> blib$animationCache = new HashMap<>();
 
     @Unique
-    private final Map<ResourceLocation, AnimatableTexture> blit$textureCache = new HashMap<>();
+    private final Map<ResourceLocation, AnimatableTexture> blib$textureCache = new HashMap<>();
 
     @Shadow
     public abstract void register(ResourceLocation resourceLocation, AbstractTexture abstractTexture);
@@ -38,7 +38,7 @@ public abstract class TextureManagerMixin {
         cancellable = true,
         require = 0
     )
-    private void blit$replaceAnimatableTexture(
+    private void blib$replaceAnimatableTexture(
         ResourceLocation location,
         CallbackInfoReturnable<AbstractTexture> cir
     ) {
@@ -48,18 +48,18 @@ public abstract class TextureManagerMixin {
             return;
         }
 
-        if (blit$textureCache.containsKey(location)) {
-            cir.setReturnValue(blit$textureCache.get(location));
+        if (blib$textureCache.containsKey(location)) {
+            cir.setReturnValue(blib$textureCache.get(location));
             return;
         }
 
-        var cached = blit$animationCache.get(location);
+        var cached = blib$animationCache.get(location);
         if (cached != null && !cached) {
             return;
         }
 
-        if (!blit$hasAnimationMetadata(location)) {
-            blit$animationCache.put(location, false);
+        if (!blib$hasAnimationMetadata(location)) {
+            blib$animationCache.put(location, false);
             return;
         }
 
@@ -68,24 +68,24 @@ public abstract class TextureManagerMixin {
         try {
             loadTexture(location, animatableTexture);
         } catch (Exception e) {
-            blit$animationCache.put(location, false);
+            blib$animationCache.put(location, false);
             return;
         }
 
         if (!animatableTexture.isAnimated()) {
-            blit$animationCache.put(location, false);
+            blib$animationCache.put(location, false);
             return;
         }
 
-        blit$animationCache.put(location, true);
-        blit$textureCache.put(location, animatableTexture);
+        blib$animationCache.put(location, true);
+        blib$textureCache.put(location, animatableTexture);
 
         this.register(location, animatableTexture);
         cir.setReturnValue(animatableTexture);
     }
 
     @Unique
-    private boolean blit$hasAnimationMetadata(ResourceLocation texture) {
+    private boolean blib$hasAnimationMetadata(ResourceLocation texture) {
         var mcmeta = ResourceLocation.fromNamespaceAndPath(
             texture.getNamespace(),
             texture.getPath() + ".mcmeta"

--- a/common/src/main/java/com/blib/internal/mixin/azurelib/TextureManagerMixin.java
+++ b/common/src/main/java/com/blib/internal/mixin/azurelib/TextureManagerMixin.java
@@ -1,22 +1,36 @@
 package com.blib.internal.mixin.azurelib;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.client.renderer.texture.SimpleTexture;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.resources.ResourceLocation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.blib.api.client.texture.v1.AnimatableTexture;
 
-@Mixin(value = TextureManager.class, priority = 2010)
+@Mixin(value = TextureManager.class, priority = 2015)
 public abstract class TextureManagerMixin {
+
+    @Unique
+    private final Map<ResourceLocation, Boolean> blit$animationCache = new HashMap<>();
+
+    @Unique
+    private final Map<ResourceLocation, AnimatableTexture> blit$textureCache = new HashMap<>();
 
     @Shadow
     public abstract void register(ResourceLocation resourceLocation, AbstractTexture abstractTexture);
+
+    @Shadow
+    protected abstract AbstractTexture loadTexture(ResourceLocation path, AbstractTexture texture);
 
     @Inject(
         method = "getTexture(Lnet/minecraft/resources/ResourceLocation;)Lnet/minecraft/client/renderer/texture/AbstractTexture;",
@@ -24,23 +38,66 @@ public abstract class TextureManagerMixin {
         cancellable = true,
         require = 0
     )
-    private void blib$replaceAnimatableTexture(
+    private void blit$replaceAnimatableTexture(
         ResourceLocation location,
         CallbackInfoReturnable<AbstractTexture> cir
     ) {
-        AbstractTexture currentTexture = cir.getReturnValue();
+        var currentTexture = cir.getReturnValue();
 
         if (currentTexture == null || currentTexture.getClass() != SimpleTexture.class) {
             return;
         }
 
-        AnimatableTexture animatableTexture = new AnimatableTexture(location);
-
-        if (!animatableTexture.isAnimated()) {
+        if (blit$textureCache.containsKey(location)) {
+            cir.setReturnValue(blit$textureCache.get(location));
             return;
         }
 
+        var cached = blit$animationCache.get(location);
+        if (cached != null && !cached) {
+            return;
+        }
+
+        if (!blit$hasAnimationMetadata(location)) {
+            blit$animationCache.put(location, false);
+            return;
+        }
+
+        var animatableTexture = new AnimatableTexture(location);
+
+        try {
+            loadTexture(location, animatableTexture);
+        } catch (Exception e) {
+            blit$animationCache.put(location, false);
+            return;
+        }
+
+        if (!animatableTexture.isAnimated()) {
+            blit$animationCache.put(location, false);
+            return;
+        }
+
+        blit$animationCache.put(location, true);
+        blit$textureCache.put(location, animatableTexture);
+
         this.register(location, animatableTexture);
         cir.setReturnValue(animatableTexture);
+    }
+
+    @Unique
+    private boolean blit$hasAnimationMetadata(ResourceLocation texture) {
+        var mcmeta = ResourceLocation.fromNamespaceAndPath(
+            texture.getNamespace(),
+            texture.getPath() + ".mcmeta"
+        );
+
+        try {
+            return Minecraft.getInstance()
+                .getResourceManager()
+                .getResource(mcmeta)
+                .isPresent();
+        } catch (Exception e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
This fixes an issue where Blib (since has a built-in fork of Azurelib) if loaded with Gankolib and a gankolib mod uses animated textures, it breaks Gankolibs. 